### PR TITLE
fix: 修复了解更多按钮点击时的滚动抽搐问题

### DIFF
--- a/src/components/MorphModal.vue
+++ b/src/components/MorphModal.vue
@@ -135,12 +135,11 @@ export default {
     },
 
     lockBodyScroll() {
-      this.bodyOverflow = document.body.style.overflow
-      document.body.style.overflow = 'hidden'
+      // 不锁定 body 滚动，避免滚动条消失导致页面宽度跳动（抽搐）
     },
 
     unlockBodyScroll() {
-      document.body.style.overflow = this.bodyOverflow || ''
+      // 对应 lockBodyScroll，无需恢复
     },
 
     getButtonRect() {

--- a/src/style.css
+++ b/src/style.css
@@ -76,6 +76,14 @@ html:not([data-theme]) {
 
 
 /* ===== 基础样式 ===== */
+
+/* 预留滚动条空间，防止模态框打开/关闭时页面宽度跳动（滚动抽搐根本修复）
+   注意：scrollbar-gutter 必须加在实际滚动容器（body）上，
+   且要求 overflow 不为 hidden，故将 overflow-x 改为 clip */
+html {
+  scrollbar-gutter: stable;
+}
+
 a {
   font-weight: 500;
   color: var(--primary-color);
@@ -89,7 +97,8 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  overflow-x: hidden;
+  overflow-x: clip;   /* clip 裁剪横向溢出但不创建滚动容器，不影响 scrollbar-gutter */
+  scrollbar-gutter: stable; /* 预留纵向滚动条空间，防止模态框开关时页面宽度跳动 */
   color: var(--text-color);
   background-color: var(--background-color);
   /* 背景图设在 body 上，是 backdrop-filter 能正确模糊的关键 */


### PR DESCRIPTION
## 问题描述

点击了解更多按钮打开模态框时，页面会出现明显的横向抖动（抽搐）。

## 根本原因

`lockBodyScroll()` 在模态框打开时将 `body.overflow` 设为 `hidden`，导致纵向滚动条消失，页面可用宽度突然增加约 15px，引发布局重排和视觉抖动。

## 修复方案

### `src/components/MorphModal.vue`
- 清空 `lockBodyScroll()` 和 `unlockBodyScroll()` 的实现，模态框打开时**不再锁定 body 滚动**，从根本上避免宽度变化

### `src/style.css`
- 将 `body` 的 `overflow-x: hidden` 改为 `overflow-x: clip`
- 在 `body` 上添加 `scrollbar-gutter: stable`（预留滚动条空间）

## 测试

点击任意词条的了解更多，页面不再发生横向抖动。