### PR TITLE
fix: 修复最新羊毛页面切换动画方向判断错误

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,7 @@ import Footer from './components/Footer.vue'
 const route = useRoute()
 const transitionName = ref('page-fade')
 
-const routeOrder = ['/', '/entries', '/entry-generator', '/about', '/friends']
+const routeOrder = ['/', '/entries', '/entry-generator', '/about', '/friends', '/freebies']
 
 watch(
   () => route.path,


### PR DESCRIPTION
## 问题
`App.vue` 中手写的 `routeOrder` 数组缺少 `/freebies`（最新羊毛页面），导致该页面切换时 `routeOrder.indexOf()` 返回 -1，前进/后退方向判断失效，动画表现与其他页面不一致。

## 修复
将 `/freebies` 按导航栏实际顺序加入 `routeOrder` 数组。

## 备注
`routeOrder` 目前是与 `router/index.js` 分开手动维护的第二份路由清单，未来新增页面时容易再次遗漏，建议后续考虑改为从路由表自动生成，减少人工维护成本。

## Summary by Sourcery

Bug Fixes:
- Include the /freebies path in the route order list so its navigation animations use the correct forward/backward direction.