### PR TITLE
fix: 修复卡片背景模糊在动画期间消失问题

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -56,12 +56,20 @@ watch(
 
 /* ===== 页面切换动画 =====
    使用 mode="out-in"：旧页面先离开，新页面再进入
-   注意：不要在 .page-wrapper（祖先元素）上使用 filter。
-   页面内部大量子组件依赖 backdrop-filter 实现毛玻璃效果，
-   而祖先一旦带有 filter，会为其建立新的层叠上下文，
-   导致子元素的 backdrop-filter 无法正确采样到页面背景，
-   毛玻璃效果会在动画期间"消失"，动画结束、filter 恢复为
-   none 后才复原。因此这里只用 opacity + transform 过渡。
+
+   毛玻璃消失问题的真正根因：
+   transform、filter 等属性会让应用它们的元素成为新的层叠上下文根，
+   其子元素的 backdrop-filter 只能在这个根内部采样背景。而背景图是
+   设在 <body> 上的（见 style.css），.page-wrapper 自身没有背景。
+   动画期间 .page-wrapper 带有 transform，子元素的毛玻璃卡片就只能
+   看到隔离层内部空空如也的内容，效果因此在动画期间"消失"，动画
+   结束、transform 归零、隔离解除后才恢复正常。
+   （之前只去掉了 filter: blur，但 transform 同样会触发隔离，
+   所以问题并未真正解决。）
+
+   修复思路：不放弃 transform（避免用 left/margin 做动画导致重排、
+   性能变差），而是给 .page-wrapper 补一份背景（见下方 ::before），
+   让隔离层内部本身就有内容可供毛玻璃采样。
 */
 
 /* Fade（默认）*/
@@ -107,5 +115,23 @@ watch(
 /* 页面容器 */
 .page-wrapper {
   /* 移除 contain: layout，因为它会创建一个新的包含块，导致子元素的 fixed 定位相对于该容器而非视口 */
+  position: relative;
+}
+
+/* 补一份与 body 一致的背景，垫在页面内容之下。
+   平时（无 transform 时）与 body 背景完全重叠，肉眼看不出差异；
+   动画期间 .page-wrapper 成为层叠上下文根时，
+   子元素的 backdrop-filter 就能在这个根内部采样到这份背景，
+   而不是看到空白，从而在动画全程保持毛玻璃效果不消失。 */
+.page-wrapper::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image: var(--bg-image);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 </style>


### PR DESCRIPTION
## 背景
#42 只去掉了 `filter: blur()`，但没有解决 `transform: translateX()` 同样会触发层叠上下文隔离的问题，所以毛玻璃消失的 bug 依旧存在。本 PR 替代 #42 提供彻底修复。

## 根因
CSS 中 `transform`、`filter` 等属性会让应用它们的元素成为新的层叠上下文根，子元素的 `backdrop-filter` 只能在这个根内部采样背景。背景图设在 `<body>` 上，`.page-wrapper` 自身没有背景。动画期间 `.page-wrapper` 带有 `transform`，子元素的毛玻璃卡片就只能看到隔离层内部空白的内容，效果因此在动画期间消失，动画结束、`transform` 归零、隔离解除后才恢复正常。

## 修复
不放弃 `transform`（避免用 `left`/`margin` 做动画导致重排、性能变差），而是给 `.page-wrapper` 用 `::before` 伪元素补一份与 `body` 一致的背景图。这样无论 `transform`/`filter` 是否触发层叠上下文隔离，隔离层内部本身就有内容可供毛玻璃采样，动画全程效果保持正常，且静止状态下与之前视觉完全一致（伪元素与 body 背景完全重叠）。

## 关联
建议关闭 #42，本 PR 替代其修复方案。

## Summary by Sourcery

Ensure page transition animations preserve the frosted glass backdrop-filter effect throughout the transform-based slide animations.

Bug Fixes:
- Fix backdrop-filter frosted glass cards disappearing during page slide animations when .page-wrapper has transform applied.

Enhancements:
- Add a ::before pseudo-element background to .page-wrapper aligned with the body background so backdrop-filter can sample a consistent background within the new stacking context.
- Update page transition CSS and inline comments to document the stacking context root cause and the new background-based solution.